### PR TITLE
do not set port if gluetun returns 0

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -7,7 +7,7 @@ qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
 port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
-if [ ! "$port_number" ]; then
+if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1
 fi


### PR DESCRIPTION
when gluetun starts up, returned port is 0. setting this in qbittorrent breaks it and it can't be accessed later to fix it without manually editing config.