### PR TITLE
fix SIGTERM

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 set -e
 
+_term() {
+  echo "Signal SIGTERM reçu, arrêt en cours..."
+  kill -TERM "$child" 2>/dev/null
+}
+
+trap _term SIGTERM
+
 ./main.sh
-/usr/sbin/crond -f -l 8
+/usr/sbin/crond -f -l 8 &
+wait "$!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 set -e
 
 _term() {
-  echo "Signal SIGTERM reçu, arrêt en cours..."
+  echo "SIGTERM signal received, shutdown in progress..."
   kill -TERM "$child" 2>/dev/null
 }
 


### PR DESCRIPTION
Without this change the entrypoint waits for the docker timeout (10s) when I do a `docker compose down`