### PR TITLE
Full implementation of Gluetun's new Control Server authentication methods + allow users to set cron job interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,6 @@ VOLUME [ "/config" ]
 
 RUN apk --no-cache add jq curl
 
-RUN echo "*/10 * * * * /bin/sh /usr/src/app/main.sh" | crontab -
-
 COPY *.sh ./
 
 CMD ["/usr/src/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -6,37 +6,95 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 ### Environment Variables
 
-| Variable     | Example                     | Default                      | Description                                                     |
-|--------------|-----------------------------|------------------------------|-----------------------------------------------------------------|
-| QBT_USERNAME | `username`                  | `admin`                      | qBittorrent username                                            |
-| QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
-| QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
-| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
+| Variable      | Example                     | Default                      | Description                                                     |
+|---------------|-----------------------------|------------------------------|-----------------------------------------------------------------|
+| INTERVAL      | `5`                         | `1`                          | Interval in minutes in-which port update will be attempted      |
+| QBT_USERNAME  | `username`                  | `admin`                      | qBittorrent username                                            |
+| QBT_PASSWORD  | `password`                  | `adminadmin`                 | qBittorrent password                                            |
+| QBT_ADDR      | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port.                 |
+| GTN_USERNAME  | `username`                  | na                           | Gluetun username set in `config.toml`                           |
+| GTN_PASSWORD  | `password`                  | na                           | Gluetun password set in `config.toml`                           |
+| GTN_APIKEY    | `4BNUzqoPxdoDTSFJrPguKM`    | na                           | Gluetun api key set in `config.toml`                            |
+| GTN_ADDR      | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port.             |
 
-## Example
+## `compose.yml` Examples
+**Before you can use qbittorrent-port-forward-gluetun-server you must first create a `config.toml`, see Gluetun's [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#control-server) documentation.** Below are three `compose.yml` examples, one for each authentication method listed in Gluetun's documentation.
 
-### Docker-Compose
-
-The following is an example docker-compose:
-
+### basic
 ```yaml
   qbittorrent-port-forward-gluetun-server:
     image: mjmeli/qbittorrent-port-forward-gluetun-server
     container_name: qbittorrent-port-forward-gluetun-server
     restart: unless-stopped
     environment:
-      - QBT_USERNAME=username
-      - QBT_PASSWORD=password
-      - QBT_ADDR=http://192.168.1.100:8080
-      - GTN_ADDR=http://192.168.1.100:8000
+      QBT_USERNAME: username
+      BT_PASSWORD: password
+      QBT_ADDR: http://192.168.1.100:8080
+      GTN_USERNAME: username
+      GTN_PASSWORD: password
+      GTN_ADDR: http://192.168.1.100:8000
+```
+
+### apikey
+```yaml
+  qbittorrent-port-forward-gluetun-server:
+    image: mjmeli/qbittorrent-port-forward-gluetun-server
+    container_name: qbittorrent-port-forward-gluetun-server
+    restart: unless-stopped
+    environment:
+      QBT_USERNAME: username
+      QBT_PASSWORD: password
+      QBT_ADDR: http://192.168.1.100:8080
+      GTN_APIKEY: apikey
+      GTN_ADDR: http://192.168.1.100:8000
+```
+
+### none
+```yaml
+  qbittorrent-port-forward-gluetun-server:
+    image: mjmeli/qbittorrent-port-forward-gluetun-server
+    container_name: qbittorrent-port-forward-gluetun-server
+    restart: unless-stopped
+    environment:
+      QBT_USERNAME: username
+      QBT_PASSWORD: password
+      QBT_ADDR: http://192.168.1.100:8080
+      GTN_ADDR: http://192.168.1.100:8000
 ```
 
 ## Development
+**Note that you must first create a `config.toml`, see Gluetun's [Control Server](https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#control-server) documentation.**
 
 ### Build Image
-
-`docker build . -t qbittorrent-port-forward-gluetun-server`
+```bash
+docker build . -t qbittorrent-port-forward-gluetun-server
+```
 
 ### Run Container
-
-`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 qbittorrent-port-forward-gluetun-server:latest`
+```bash
+docker run --rm -it /
+  -e QBT_USERNAME=admin /
+  -e QBT_PASSWORD=adminadmin /
+  -e QBT_ADDR=http://192.168.1.100:8080 /
+  -e GTN_USERNAME=username /
+  -e GTN_PASSWORD=password /
+  -e GTN_ADDR=http://192.168.1.100:8000 /
+  qbittorrent-port-forward-gluetun-server
+```
+```bash
+docker run --rm -it /
+  -e QBT_USERNAME=admin /
+  -e QBT_PASSWORD=adminadmin /
+  -e QBT_ADDR=http://192.168.1.100:8080 /
+  -e GTN_APIKEY=apikey /
+  -e GTN_ADDR=http://192.168.1.100:8000 /
+  qbittorrent-port-forward-gluetun-server
+```
+```bash
+docker run --rm -it /
+  -e QBT_USERNAME=admin /
+  -e QBT_PASSWORD=adminadmin /
+  -e QBT_ADDR=http://192.168.1.100:8080 /
+  -e GTN_ADDR=http://192.168.1.100:8000 /
+  qbittorrent-port-forward-gluetun-server
+```

--- a/README.md
+++ b/README.md
@@ -22,44 +22,44 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 ### basic
 ```yaml
-  qbittorrent-port-forward-gluetun-server:
-    image: mjmeli/qbittorrent-port-forward-gluetun-server
-    container_name: qbittorrent-port-forward-gluetun-server
-    restart: unless-stopped
-    environment:
-      QBT_USERNAME: username
-      BT_PASSWORD: password
-      QBT_ADDR: http://192.168.1.100:8080
-      GTN_USERNAME: username
-      GTN_PASSWORD: password
-      GTN_ADDR: http://192.168.1.100:8000
+qbittorrent-port-forward-gluetun-server:
+  image: mjmeli/qbittorrent-port-forward-gluetun-server
+  container_name: qbittorrent-port-forward-gluetun-server
+  restart: unless-stopped
+  environment:
+    QBT_USERNAME: username
+    BT_PASSWORD: password
+    QBT_ADDR: http://192.168.1.100:8080
+    GTN_USERNAME: username
+    GTN_PASSWORD: password
+    GTN_ADDR: http://192.168.1.100:8000
 ```
 
 ### apikey
 ```yaml
-  qbittorrent-port-forward-gluetun-server:
-    image: mjmeli/qbittorrent-port-forward-gluetun-server
-    container_name: qbittorrent-port-forward-gluetun-server
-    restart: unless-stopped
-    environment:
-      QBT_USERNAME: username
-      QBT_PASSWORD: password
-      QBT_ADDR: http://192.168.1.100:8080
-      GTN_APIKEY: apikey
-      GTN_ADDR: http://192.168.1.100:8000
+qbittorrent-port-forward-gluetun-server:
+  image: mjmeli/qbittorrent-port-forward-gluetun-server
+  container_name: qbittorrent-port-forward-gluetun-server
+  restart: unless-stopped
+  environment:
+    QBT_USERNAME: username
+    QBT_PASSWORD: password
+    QBT_ADDR: http://192.168.1.100:8080
+    GTN_APIKEY: apikey
+    GTN_ADDR: http://192.168.1.100:8000
 ```
 
 ### none
 ```yaml
-  qbittorrent-port-forward-gluetun-server:
-    image: mjmeli/qbittorrent-port-forward-gluetun-server
-    container_name: qbittorrent-port-forward-gluetun-server
-    restart: unless-stopped
-    environment:
-      QBT_USERNAME: username
-      QBT_PASSWORD: password
-      QBT_ADDR: http://192.168.1.100:8080
-      GTN_ADDR: http://192.168.1.100:8000
+qbittorrent-port-forward-gluetun-server:
+  image: mjmeli/qbittorrent-port-forward-gluetun-server
+  container_name: qbittorrent-port-forward-gluetun-server
+  restart: unless-stopped
+  environment:
+    QBT_USERNAME: username
+    QBT_PASSWORD: password
+    QBT_ADDR: http://192.168.1.100:8080
+    GTN_ADDR: http://192.168.1.100:8000
 ```
 
 ## Development

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,4 +2,10 @@
 set -e
 
 ./main.sh
+
+INTERVAL="${INTERVAL:-1}"
+
+echo "*/${INTERVAL} * * * * /bin/sh /usr/src/app/main.sh" | crontab -
+echo "$(date): Cron job Configured to run every ${INTERVAL} minute(s)"
+
 /usr/sbin/crond -f -l 8

--- a/main.sh
+++ b/main.sh
@@ -3,13 +3,25 @@ set -e
 
 qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
-qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
-gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
+qbt_addr="${QBT_ADDR:-http://localhost:8080}"
+gtn_addr="${GTN_ADDR:-http://localhost:8000}"
 
-port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
-if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
+if [[ -n "$GTN_USERNAME" && -n "$GTN_PASSWORD" ]]; then
+    echo "Attempting to retrieve port from Gluetun via username and password..."
+    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+elif [ -n "$GTN_APIKEY" ]; then
+    echo "Attempting to retrieve port from Gluetun via api key..."
+    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+else
+    echo "Attempting to retrieve port from Gluetun without authentication..."
+    port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+fi
+
+if [[ ! "$port_number"  ||  "$port_number" = "0" ]]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1
+else
+    echo "Port number succesfully retrieved from Gluetun: $port_number"
 fi
 
 curl --fail --silent --show-error --cookie-jar /tmp/cookies.txt --cookie /tmp/cookies.txt --header "Referer: $qbt_addr" --data "username=$qbt_username" --data "password=$qbt_password" $qbt_addr/api/v2/auth/login 1> /dev/null


### PR DESCRIPTION
# changes
- implemented needed changes for interoperability with Gluetun's Control Server authentication methods
- refactored `Dockerfile` & `entrypoint.sh` to allow users to set the cron job interval
- Changed default cron job interval from 10 minutes to 1 minute. 

# why?
- Gluetun's Control Server requires an authentication method after `v3.40.0` by default. I see that there's another PR for this, but it only allows for apikey authentication, even though there are three different methods (basic, apikey, none). This PR accounts for all three methods.
- I found that with the previous interval of 10 minutes, there was a chance that the VPN connection was already fire-walled by the time this service could update the port on qBittorrents end. By setting the default interval to 1 minute, you greatly reduce the odds of this happening. Users can manually set the interval to whatever they want, if they feel that 1 minute is too frequent.