### PR TITLE
Support all Gluetun control server authentication methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,18 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 
 ## Gluetun Control Server Authentication
-1. Generate api key using the following command: `docker run --rm qmcgaw/gluetun genkey`
-2. Create a new file on your Gluetun host system with the following contents:
-```toml# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
+1. Create a new file on your Gluetun host system with the following contents:
+```toml
+# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
 [[roles]]
 name = "qbittorrent"
 # Define a list of routes with the syntax "Http-Method /path"
 routes = ["GET /v1/openvpn/portforwarded"]
 # Define an authentication method with its parameters
 auth = "apikey"
-apikey = "CHANGEME" # generate using "docker run --rm qmcgaw/gluetun genkey"
+apikey = "CHANGEME" # can be generated using "docker run --rm qmcgaw/gluetun genkey"
 ```
-3. Bind mount the file you created to `/gluetun/auth/config.toml`.
+3. Bind mount the file you created to `/gluetun/auth/config.toml` in your gluetun docker instance.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ A shell script and Docker container for automatically setting qBittorrent's list
 | QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
 | QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
 | GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
+| GTN_APIKEY   | `apikey`                    | `CHANGEME`                   | API Key for communication to gluetun control server             |
+
+
+## Gluetun Control Server Authentication
+1. Generate api key using the following command: `docker run --rm qmcgaw/gluetun genkey`
+2. Create a new file on your Gluetun host system with the following contents:
+```toml# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
+[[roles]]
+name = "qbittorrent"
+# Define a list of routes with the syntax "Http-Method /path"
+routes = ["GET /v1/openvpn/portforwarded"]
+# Define an authentication method with its parameters
+auth = "apikey"
+apikey = "CHANGEME" # generate using "docker run --rm qmcgaw/gluetun genkey"
+```
+3. Bind mount the file you created to `/gluetun/auth/config.toml`.
 
 ## Example
 
@@ -29,6 +45,7 @@ The following is an example docker-compose:
       - QBT_PASSWORD=password
       - QBT_ADDR=http://192.168.1.100:8080
       - GTN_ADDR=http://192.168.1.100:8000
+      - GTN_APIKEY=apikey
 ```
 
 ## Development
@@ -39,4 +56,4 @@ The following is an example docker-compose:
 
 ### Run Container
 
-`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 qbittorrent-port-forward-gluetun-server:latest`
+`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest`

--- a/README.md
+++ b/README.md
@@ -6,28 +6,26 @@ A shell script and Docker container for automatically setting qBittorrent's list
 
 ### Environment Variables
 
-| Variable     | Example                     | Default                      | Description                                                     |
-|--------------|-----------------------------|------------------------------|-----------------------------------------------------------------|
-| QBT_USERNAME | `username`                  | `admin`                      | qBittorrent username                                            |
-| QBT_PASSWORD | `password`                  | `adminadmin`                 | qBittorrent password                                            |
-| QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080`      | HTTP URL for the qBittorrent web UI, with port                  |
-| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000`      | HTTP URL for the gluetun control server, with port              |
-| GTN_APIKEY   | `apikey`                    | `CHANGEME`                   | API Key for communication to gluetun control server             |
+| Variable     | Example                     | Default                 | Description                                                                    |
+|--------------|-----------------------------|-------------------------|--------------------------------------------------------------------------------|
+| QBT_USERNAME | `username`                  | `admin`                 | qBittorrent username                                                           |
+| QBT_PASSWORD | `password`                  | `adminadmin`            | qBittorrent password                                                           |
+| QBT_ADDR     | `http://192.168.1.100:8080` | `http://localhost:8080` | HTTP URL for the qBittorrent web UI, with port                                 |
+| GTN_ADDR     | `http://192.168.1.100:8000` | `http://localhost:8000` | HTTP URL for the gluetun control server, with port                             |
+| GTN_USERNAME | `username`                  | *None*                  | Username for authentication to gluetun control server (if basic auth enabled)  |
+| GTN_PASSWORD | `password`                  | *None*                  | Password for authentication to gluetun control server (if basic auth enabled)  |
+| GTN_APIKEY   | `apikey`                    | *None*                  | API Key for authentication to gluetun control server (if API key auth enabled) |
 
 
 ## Gluetun Control Server Authentication
-1. Create a new file on your Gluetun host system with the following contents:
-```toml
-# See https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md for more
-[[roles]]
-name = "qbittorrent"
-# Define a list of routes with the syntax "Http-Method /path"
-routes = ["GET /v1/openvpn/portforwarded"]
-# Define an authentication method with its parameters
-auth = "apikey"
-apikey = "CHANGEME" # can be generated using "docker run --rm qmcgaw/gluetun genkey"
-```
-3. Bind mount the file you created to `/gluetun/auth/config.toml` in your gluetun docker instance.
+Starting in Gluetun v3.4, it is required to setup authentication on the Gluetun control server routes.
+
+See this link for information on how to set this up: https://github.com/qdm12/gluetun-wiki/blob/main/setup/advanced/control-server.md#authentication
+
+Once configured in Gluetun, you can configure this container to use the appropriate authentication method:
+- If using `none` auth, you do not need to provide any of the authentication environment variables
+- If using `basic` auth, you should set the `GTN_USERNAME` and `GTN_PASSWORD` environment variables
+- If using `apikey` auth, you should set the `GTN_APIKEY` environment variable
 
 ## Example
 
@@ -45,15 +43,17 @@ The following is an example docker-compose:
       - QBT_PASSWORD=password
       - QBT_ADDR=http://192.168.1.100:8080
       - GTN_ADDR=http://192.168.1.100:8000
-      - GTN_APIKEY=apikey
+      - GTN_APIKEY=CHANGEME
 ```
 
 ## Development
 
 ### Build Image
-
-`docker build . -t qbittorrent-port-forward-gluetun-server`
+```bash
+docker build . -t qbittorrent-port-forward-gluetun-server
+```
 
 ### Run Container
-
-`docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest`
+```bash
+docker run --rm -it -e QBT_USERNAME=admin -e QBT_PASSWORD=adminadmin -e QBT_ADDR=http://192.168.1.100:8080 -e GTN_ADDR=http://192.168.1.100:8000 -e GTN_APIKEY=CHANGEME qbittorrent-port-forward-gluetun-server:latest
+```

--- a/main.sh
+++ b/main.sh
@@ -5,8 +5,9 @@ qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
+gtn_apikey="${GTN_APIKEY:-CHANGEME}"
 
-port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -6,7 +6,7 @@ qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
-port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1

--- a/main.sh
+++ b/main.sh
@@ -5,12 +5,23 @@ qbt_username="${QBT_USERNAME:-admin}"
 qbt_password="${QBT_PASSWORD:-adminadmin}"
 qbt_addr="${QBT_ADDR:-http://localhost:8080}" # ex. http://10.0.1.48:8080
 gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
-gtn_apikey="${GTN_APIKEY:-CHANGEME}"
 
-port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+if [[ -n "$GTN_USERNAME" && -n "$GTN_PASSWORD" ]]; then
+    echo "Attempting to retrieve port from Gluetun via username and password..."
+    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+elif [ -n "$GTN_APIKEY" ]; then
+    echo "Attempting to retrieve port from Gluetun via api key..."
+    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+else
+    echo "Attempting to retrieve port from Gluetun without authentication..."
+    port_number=$(curl --fail --silent --show-error  $GTN_ADDR/v1/openvpn/portforwarded | jq '.port')
+fi
+
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then
     echo "Could not get current forwarded port from gluetun, exiting..."
     exit 1
+else
+    echo "Port number succesfully retrieved from Gluetun: $port_number"
 fi
 
 curl --fail --silent --show-error --cookie-jar /tmp/cookies.txt --cookie /tmp/cookies.txt --header "Referer: $qbt_addr" --data "username=$qbt_username" --data "password=$qbt_password" $qbt_addr/api/v2/auth/login 1> /dev/null


### PR DESCRIPTION
Combines the changes in #5 with additional changes to support username/password auth and also continue to support no authentication by default.