### PR TITLE
New address to obtain port

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -8,13 +8,13 @@ gtn_addr="${GTN_ADDR:-http://localhost:8000}" # ex. http://10.0.1.48:8000
 
 if [[ -n "$GTN_USERNAME" && -n "$GTN_PASSWORD" ]]; then
     echo "Attempting to retrieve port from Gluetun via username and password..."
-    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error --user "$GTN_USERNAME:$GTN_PASSWORD" $gtn_addr/v1/portforward | jq '.port')
 elif [ -n "$GTN_APIKEY" ]; then
     echo "Attempting to retrieve port from Gluetun via api key..."
-    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error --header "X-API-Key: $GTN_APIKEY" $gtn_addr/v1/portforward | jq '.port')
 else
     echo "Attempting to retrieve port from Gluetun without authentication..."
-    port_number=$(curl --fail --silent --show-error  $gtn_addr/v1/openvpn/portforwarded | jq '.port')
+    port_number=$(curl --fail --silent --show-error  $gtn_addr/v1/portforward | jq '.port')
 fi
 
 if [ ! "$port_number" ] || [ "$port_number" = "0" ]; then


### PR DESCRIPTION
With the latest gluetun release, the curl command in this script now returns `<a href="/v1/portforward">Moved Permanently</a>.` rather than the port number.

https://github.com/qdm12/gluetun/commit/3d1b6bc861e33468911842464213ca3289211191 This commit yesterday turned the `/v1/openvpn/portforwarded` address into a redirect toward `/v1/portforward`, breaking this script. Technically keeping the URL the same and adding a `--location` option to follow the redirect would be fine, but seems like the URL is due to change anyway so might as well change it here.