### PR TITLE
Better docker tags

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -41,6 +41,7 @@ jobs:
           push: true
           tags: |
             mjmeli/${{ github.event.repository.name }}:latest
+            mjmeli/${{ github.event.repository.name }}:${{ github.sha }}
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:${{ github.sha }}
 

--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -1,0 +1,65 @@
+name: Build and push release image
+
+on:
+  release:
+    types: [created]
+  # workflow_dispatch allows manual triggering to backfill Docker images for existing releases
+  # Go to Actions > Build and push release image > Run workflow, then enter the tag name
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag name (e.g., v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  packages: write
+
+jobs:
+  build_and_push_release_image:
+    name: Build Docker image and push to registries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: mjmeli
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Determine tag name: use release tag when triggered by release event,
+      # otherwise use the tag_name input from workflow_dispatch (for backfilling)
+      - name: Set tag name
+        id: set_tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        id: docker_build_push
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: |
+            mjmeli/${{ github.event.repository.name }}:${{ steps.set_tag.outputs.tag }}
+            ghcr.io/${{ github.repository }}:${{ steps.set_tag.outputs.tag }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build_push.outputs.digest }}
+


### PR DESCRIPTION
This pull request improves the Docker image build and release process by adding a dedicated workflow for building and pushing images on release events, as well as enhancing the tagging strategy in the existing build workflow. The main changes are the introduction of a new release workflow and the addition of commit SHA-based tags for Docker images.

**Docker image build and release process improvements:**

* Added a new workflow file, `.github/workflows/release-image.yml`, which builds and pushes Docker images to DockerHub and GitHub Container Registry when a release is created or when manually triggered for backfilling. The workflow supports specifying a release tag and includes authentication steps for both registries.
* Updated the existing `.github/workflows/build-and-push-image.yml` workflow to also tag built images with the current commit SHA, in addition to the `latest` tag, for both DockerHub and GitHub Container Registry.…ff releases