### PR TITLE
additional improvements

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -2,7 +2,7 @@ name: Build and push release image
 
 on:
   release:
-    types: [created]
+    types: [published]
   # workflow_dispatch allows manual triggering to backfill Docker images for existing releases
   # Go to Actions > Build and push release image > Run workflow, then enter the tag name
   workflow_dispatch:
@@ -20,8 +20,22 @@ jobs:
     name: Build Docker image and push to registries
     runs-on: ubuntu-latest
     steps:
+      # Determine tag name: use release tag when triggered by release event,
+      # otherwise use the tag_name input from workflow_dispatch (for backfilling)
+      - name: Set tag name
+        id: set_tag
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          # Checkout the release tag commit
+          ref: ${{ steps.set_tag.outputs.tag }}
 
       - name: Set up Docker Buildx
         id: buildx
@@ -39,17 +53,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      # Determine tag name: use release tag when triggered by release event,
-      # otherwise use the tag_name input from workflow_dispatch (for backfilling)
-      - name: Set tag name
-        id: set_tag
-        run: |
-          if [ "${{ github.event_name }}" = "release" ]; then
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
-          else
-            echo "tag=${{ inputs.tag_name }}" >> $GITHUB_OUTPUT
-          fi
 
       - name: Build and push
         id: docker_build_push


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing release Docker images. The main focus is to ensure the workflow is triggered on the correct release event and that the Docker image is built from the appropriate commit, especially when manually backfilling images.

Workflow trigger improvements:

* Changed the workflow trigger from the `created` release event to the `published` event, ensuring images are only built for finalized releases.

Build process reliability:

* Moved the logic for determining the Docker image tag and the corresponding commit to the beginning of the job, ensuring the correct tag is used whether triggered by a release or manually via `workflow_dispatch`.
* Updated the `actions/checkout` step to explicitly check out the commit corresponding to the determined tag, ensuring the Docker image is built from the correct source code.
* Removed the redundant tag-determining step from later in the workflow, as this logic is now handled at the start.